### PR TITLE
Add Sim

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -22,7 +22,7 @@ class Sim(Game):
         return state.encode()
     def grammar(self):
         grammar = {}
-        positions = {v: (1000*cos(v*pi/3), 1000*sin(v*pi/3)) for v in self.engine.vertices}
+        positions = {v: (1000*cos((v+4)*pi/3), 1000*sin((v+4)*pi/3)) for v in self.engine.vertices}
         for edge in self.engine.edges:
             grammar[f'r{self.engine.edge_ids[edge]}'] = f'<line x1="{positions[edge[0]][0]}" y1="{positions[edge[0]][1]}" x2="{positions[edge[1]][0]}" y2="{positions[edge[1]][1]}" stroke="red" stroke-width="20" />'
             grammar[f'b{self.engine.edge_ids[edge]}'] = f'<line x1="{positions[edge[0]][0]}" y1="{positions[edge[0]][1]}" x2="{positions[edge[1]][0]}" y2="{positions[edge[1]][1]}" stroke="blue" stroke-width="20" />'

--- a/sim.py
+++ b/sim.py
@@ -43,12 +43,12 @@ class Sim(Game):
 </g>
 <g transform="scale(1.128 1.128)" font-family="Verdana" font-size="126" text-anchor="middle">
 <text>
-<tspan x="{positions[0][0]}" y="{positions[0][1]}" alignment-baseline="central">0</tspan>
-<tspan x="{positions[1][0]}" y="{positions[1][1]}" alignment-baseline="central">1</tspan>
-<tspan x="{positions[2][0]}" y="{positions[2][1]}" alignment-baseline="central">2</tspan>
-<tspan x="{positions[3][0]}" y="{positions[3][1]}" alignment-baseline="central">3</tspan>
-<tspan x="{positions[4][0]}" y="{positions[4][1]}" alignment-baseline="central">4</tspan>
-<tspan x="{positions[5][0]}" y="{positions[5][1]}" alignment-baseline="central">5</tspan>
+<tspan x="{positions[0][0]}" y="{positions[0][1]}" alignment-baseline="central">1</tspan>
+<tspan x="{positions[1][0]}" y="{positions[1][1]}" alignment-baseline="central">2</tspan>
+<tspan x="{positions[2][0]}" y="{positions[2][1]}" alignment-baseline="central">3</tspan>
+<tspan x="{positions[3][0]}" y="{positions[3][1]}" alignment-baseline="central">4</tspan>
+<tspan x="{positions[4][0]}" y="{positions[4][1]}" alignment-baseline="central">5</tspan>
+<tspan x="{positions[5][0]}" y="{positions[5][1]}" alignment-baseline="central">6</tspan>
 </text>
 </g>
 </g>
@@ -60,7 +60,7 @@ class Sim(Game):
         grammar['result'] = '#only#'
         return grammar
     def display_input(self, input):
-        return ' '.join(map(str, self.engine.edges[input]))
+        return ' '.join(str(v+1) for v in self.engine.edges[input])
 
 if __name__ == '__main__':
     Sim().tracerise('sim')

--- a/sim.py
+++ b/sim.py
@@ -9,7 +9,13 @@ class Sim(Game):
         self.engine.map_state_space()
         self.engine.perform_minimax()
     def start_states(self):
-        return [(SimState.initial_state(), "Would you like to play a game of Sim?\n")]
+        initial_state = SimState.initial_state()
+        details = self.engine.state_details[initial_state]
+        second_state = details.successors[details.optimal_play]
+        return [
+            (initial_state, "Would you like to play a game of Sim?\n"),
+            (second_state, "Would you like to play a game of Sim? I'll start.\n")
+            ]
     def options(self, state):
         return list(self.engine.state_details[state].successors.keys())
     def result(self, state, input):

--- a/sim.py
+++ b/sim.py
@@ -1,0 +1,56 @@
+from game import Game
+from sim_engine import SimEngine, SimState, Colour
+from math import sin, cos, pi
+
+
+class Sim(Game):
+    def __init__(self):
+        self.engine = SimEngine()
+        self.engine.map_state_space()
+        self.engine.perform_minimax()
+    def start_states(self):
+        return [(SimState.initial_state(), "Would you like to play a game of Sim?\n")]
+    def options(self, state):
+        return list(self.engine.state_details[state].successors.keys())
+    def result(self, state, input):
+        return {'only': [self.engine.state_details[state].successors[input]]}
+    def display(self, state):
+        set_colours = ''.join(f'[{e}:#{c.name[0]}{e}#]' for (e, c) in enumerate(state.colours) if c is not Colour.empty)
+        return '#init#' + set_colours + '#display#'
+        
+    def encode(self, state):
+        return state.encode()
+    def grammar(self):
+        grammar = {}
+        positions = {v: (1000*cos(v*pi/3), 1000*sin(v*pi/3)) for v in self.engine.vertices}
+        for edge in self.engine.edges:
+            grammar[f'r{self.engine.edge_ids[edge]}'] = f'<line x1="{positions[edge[0]][0]}" y1="{positions[edge[0]][1]}" x2="{positions[edge[1]][0]}" y2="{positions[edge[1]][1]}" stroke="red" stroke-width="20" />'
+            grammar[f'b{self.engine.edge_ids[edge]}'] = f'<line x1="{positions[edge[0]][0]}" y1="{positions[edge[0]][1]}" x2="{positions[edge[1]][0]}" y2="{positions[edge[1]][1]}" stroke="blue" stroke-width="20" />'
+            grammar[f'e{self.engine.edge_ids[edge]}'] = f'<line x1="{positions[edge[0]][0]}" y1="{positions[edge[0]][1]}" x2="{positions[edge[1]][0]}" y2="{positions[edge[1]][1]}" stroke="black" stroke-width="15" />'
+        grammar['svg'] = f'''
+{{svg <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1600" height="900" id="Complete graph K6">
+<rect width="100%" height="100%" fill="none"/>
+<g transform="translate(350 450) scale(0.4 0.4) translate(1000 0)">
+<circle cx = "0" cy="0" r="1050" stroke="none" fill="lightgrey"/>
+#0##1##2##3##4##5##6##7##8##9##10##11##12##13##14#
+<g style="fill:green;stroke:black;stroke-width:5">
+<circle cx="{positions[0][0]}" cy="{positions[0][1]}" r="35"/>
+<circle cx="{positions[1][0]}" cy="{positions[1][1]}" r="35"/>
+<circle cx="{positions[2][0]}" cy="{positions[2][1]}" r="35"/>
+<circle cx="{positions[3][0]}" cy="{positions[3][1]}" r="35"/>
+<circle cx="{positions[4][0]}" cy="{positions[4][1]}" r="35"/>
+<circle cx="{positions[5][0]}" cy="{positions[5][1]}" r="35"/>
+</g>
+</g>
+</svg>}}
+'''.replace('\n','')
+        grammar['alt'] = ''
+        grammar['display'] = "#svg##alt#Code: #code#\nOptions: #options#"
+        grammar['init'] = ''.join(f'[{e}:#e{e}#]' for e in range(len(self.engine.edges)))
+        grammar['result'] = '#only#'
+        return grammar
+    def display_input(self, input):
+        return ' '.join(map(str, self.engine.edges[input]))
+
+if __name__ == '__main__':
+    Sim().tracerise('sim')

--- a/sim.py
+++ b/sim.py
@@ -13,7 +13,11 @@ class Sim(Game):
     def options(self, state):
         return list(self.engine.state_details[state].successors.keys())
     def result(self, state, input):
-        return {'only': [self.engine.state_details[state].successors[input]]}
+        next_state = self.engine.state_details[state].successors[input]
+        next_details = self.engine.state_details[next_state]
+        if next_details.in_progress:
+            next_state = next_details.successors[next_details.optimal_play]
+        return {'only': [next_state]}
     def display(self, state):
         set_colours = ''.join(f'[{e}:#{c.name[0]}{e}#]' for (e, c) in enumerate(state.colours) if c is not Colour.empty)
         return '#init#' + set_colours + '#display#'

--- a/sim.py
+++ b/sim.py
@@ -30,8 +30,8 @@ class Sim(Game):
         grammar['svg'] = f'''
 {{svg <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1600" height="900" id="Complete graph K6">
 <rect width="100%" height="100%" fill="none"/>
-<g transform="translate(350 450) scale(0.4 0.4) translate(1000 0)">
-<circle cx = "0" cy="0" r="1050" stroke="none" fill="lightgrey"/>
+<circle cx = "800" cy="450" r="450" stroke="none" fill="white"/>
+<g transform="translate(800 450) scale(0.37 0.37)">
 #0##1##2##3##4##5##6##7##8##9##10##11##12##13##14#
 <g style="fill:green;stroke:black;stroke-width:5">
 <circle cx="{positions[0][0]}" cy="{positions[0][1]}" r="35"/>
@@ -40,6 +40,16 @@ class Sim(Game):
 <circle cx="{positions[3][0]}" cy="{positions[3][1]}" r="35"/>
 <circle cx="{positions[4][0]}" cy="{positions[4][1]}" r="35"/>
 <circle cx="{positions[5][0]}" cy="{positions[5][1]}" r="35"/>
+</g>
+<g transform="scale(1.128 1.128)" font-family="Verdana" font-size="126" text-anchor="middle">
+<text>
+<tspan x="{positions[0][0]}" y="{positions[0][1]}" alignment-baseline="central">0</tspan>
+<tspan x="{positions[1][0]}" y="{positions[1][1]}" alignment-baseline="central">1</tspan>
+<tspan x="{positions[2][0]}" y="{positions[2][1]}" alignment-baseline="central">2</tspan>
+<tspan x="{positions[3][0]}" y="{positions[3][1]}" alignment-baseline="central">3</tspan>
+<tspan x="{positions[4][0]}" y="{positions[4][1]}" alignment-baseline="central">4</tspan>
+<tspan x="{positions[5][0]}" y="{positions[5][1]}" alignment-baseline="central">5</tspan>
+</text>
 </g>
 </g>
 </svg>}}

--- a/sim_engine.py
+++ b/sim_engine.py
@@ -48,6 +48,8 @@ class SimState(NamedTuple):
         return SimState(self.player.change(), self.colours[:index] + (self.player.colour(),) + self.colours[index+1:])
     def __str__(self):
         return '{}, {}'.format(''.join(c.name[0] for c in self.colours), self.player)
+    def encode(self):
+        return ''.join(c.name[0] for c in (self.player,) + self.colours)
 
 class StateInvariants(NamedTuple):
     player: Player

--- a/sim_engine.py
+++ b/sim_engine.py
@@ -1,0 +1,194 @@
+import networkx
+from typing import NamedTuple, Tuple, Optional, Dict
+from enum import Enum
+from math import copysign
+from itertools import combinations, chain, count
+from dataclasses import dataclass, field
+from collections import defaultdict
+from tqdm import tqdm
+
+class Colour(Enum):
+    empty = 0
+    red = 1
+    blue = 2
+    @classmethod
+    def iter_nonempty(cls):
+        yield cls.red
+        yield cls.blue
+
+class Player(Enum):
+    red = False
+    blue = True
+    def change(self):
+        return Player(not self.value)
+    def colour(self):
+        return Colour.blue if self.value else Colour.red
+    def win_value(self):
+        return 1000 if self.value else -1000
+    def optimiser(self):
+        return max if self.value else min
+    def __str__(self):
+        return '{} player'.format(self.name).capitalize()
+
+class SimState(NamedTuple):
+    player: Player
+    colours: Tuple[
+        Colour, Colour, Colour, Colour, Colour,
+        Colour, Colour, Colour, Colour,
+        Colour, Colour, Colour,
+        Colour, Colour,
+        Colour
+    ]
+    @classmethod
+    def initial_state(cls):
+        return cls(Player.red, (Colour.empty,)*15)
+    def options(self):
+        return (i for (i, c) in enumerate(self.colours) if c is Colour.empty)
+    def apply(self, index):
+        return SimState(self.player.change(), self.colours[:index] + (self.player.colour(),) + self.colours[index+1:])
+    def __str__(self):
+        return '{}, {}'.format(''.join(c.name[0] for c in self.colours), self.player)
+
+class StateInvariants(NamedTuple):
+    player: Player
+    degree_sequence: Tuple[
+        Tuple[int,int],Tuple[int,int],Tuple[int,int],
+        Tuple[int,int],Tuple[int,int],Tuple[int,int]
+    ]
+    
+
+class ColourDegree(NamedTuple):
+    red: int
+    blue: int
+
+@dataclass
+class StateDetails:
+    expanded: bool = False
+    in_progress: Optional[bool] = None
+    winner: Optional[Player] = None
+    value: Optional[int] = None
+    optimal_play: Optional[Tuple[int, int]] = None
+    successors: Dict[int, SimState] = field(default_factory=dict)
+
+class SimEngine:
+    def __init__(self):
+        self.vertices = tuple(range(6))
+        self.edges = tuple(combinations(self.vertices, 2))
+        self.edge_ids = {edge: eid for (eid, edge) in enumerate(self.edges)}
+        self.triangles = {
+            eid: tuple(
+                tuple(self.edge_ids[self.sort_edge((v, u))]
+                    for u in edge)
+                for v in self.vertices
+                if v not in edge
+            )
+            for (edge, eid) in self.edge_ids.items()
+        }
+        self.incidents = {
+            vertex: tuple(
+                self.edge_ids[e]
+                for (v, e) in 
+                chain.from_iterable(
+                    ((v, edge) for v in edge)
+                    for edge in self.edges
+                )
+                if v == vertex
+            )
+            for vertex in self.vertices
+        }
+        self.canonical_states = {}
+        self.states_by_invariants = defaultdict(list)
+        self.state_details = {}
+    def add_canonical_state(self, state):
+        self.canonical_states[state] = state
+        self.states_by_invariants[self.invariants(state)].append(state)
+        self.state_details[state] = StateDetails()
+    def sort_edge(self, edge):
+        return tuple(sorted(edge))
+    def invariants(self, state):
+        return StateInvariants(state.player, self.degree_sequence(state.colours))
+    def degree_sequence(self, colours):
+        return tuple(sorted(tuple(sum(
+                    colours[e] is c
+                    for e in self.incidents[v])
+                for c in Colour.iter_nonempty())
+            for v in self.vertices))
+    def is_isomorphic(self, colours, other_colours):
+        g1 = networkx.generators.complete_graph(6)
+        g2 = networkx.generators.complete_graph(6)
+        c1 = {edge: colour for (edge, colour) in zip(self.edges,colours)}
+        c2 = {edge: colour for (edge, colour) in zip(self.edges,other_colours)}
+        networkx.set_edge_attributes(g1, c1, 'colour')
+        networkx.set_edge_attributes(g2, c2, 'colour')
+        em = networkx.algorithms.isomorphism.categorical_edge_match('colour', Colour.empty)
+        return networkx.is_isomorphic(g1, g2, edge_match=em)
+    def canonicalise(self, state):
+        try:
+            return self.canonical_states[state]
+        except KeyError:
+            pass
+        invariants = self.invariants(state)
+        for canon_state in self.states_by_invariants[invariants]:
+            if state.player != canon_state.player:
+                continue
+            if self.is_isomorphic(state.colours, canon_state.colours):
+                self.canonical_states[state] = canon_state
+                return canon_state
+        self.add_canonical_state(state)
+        return state
+    def evaluate_state(self, state, details, last_move):
+        for (e, f) in self.triangles[last_move]:
+            if state.colours[e] == state.colours[f] == state.player.change().colour():
+                details.in_progress = False
+                details.winner = state.player
+                details.value = state.player.win_value()
+                return
+        details.in_progress = True
+                    
+    def map_state_space(self):
+        state = SimState.initial_state()
+        self.canonicalise(state)
+        self.state_details[state].in_progress = True
+        state_queue = {state}
+        for _ in tqdm(count()):
+            state = state_queue.pop()
+            details = self.state_details[state]
+            details.expanded = True
+            if details.in_progress:
+                for option in state.options():
+                    next_state = state.apply(option)
+                    next_state = self.canonicalise(next_state)
+                    details.successors[option] = next_state
+                    next_details = self.state_details[next_state]
+                    if next_details.in_progress is None:
+                        state_queue.add(next_state)
+                        self.evaluate_state(next_state, next_details, option)
+            if not state_queue:
+                break
+    def perform_minimax(self):
+        self.minimax(SimState.initial_state())
+    def minimax(self, state):
+        details = self.state_details[state]
+        if details.value is not None:
+            return details.value
+        options = [(self.minimax(next_state), option) for (option, next_state) in details.successors.items()]
+        value, edge = state.player.optimiser()(options)
+        details.optimal_play = edge
+        details.value = value - (1 if value > 0 else -1)
+        return details.value
+    def sample_game(self):
+        state = SimState.initial_state()
+        while True:
+            details = self.state_details[state]
+            print(str(state), details.value)
+            if not details.in_progress:
+                break
+            print(details.optimal_play)
+            state = details.successors[details.optimal_play]
+
+if __name__ == '__main__':
+    SE = SimEngine()
+    SE.map_state_space()
+    print(f'{len(SE.state_details)} states')
+    SE.perform_minimax()
+    SE.sample_game()

--- a/sim_engine.py
+++ b/sim_engine.py
@@ -69,7 +69,7 @@ class StateDetails:
     in_progress: Optional[bool] = None
     winner: Optional[Player] = None
     value: Optional[int] = None
-    optimal_play: Optional[Tuple[int, int]] = None
+    optimal_play: Optional[int] = None
     successors: Dict[int, SimState] = field(default_factory=dict)
 
 class SimEngine:


### PR DESCRIPTION
Extremely basic support for Sim, generates grammar and replies.
Issues:

- [ ] Cache state map and AI moves in files in order to generate grammars more quickly
- [x] Optimal moves found but not used in replies - bot currently mediates a human versus human game
- [ ] Alt-text
- [x] Label vertices
- [x] Rotate vertices to a sensible position
- [x] Rename vertices to start from 1 or even use letters
- [ ] Highlight triangles that cause loss
- [ ] Record vertex permutations and report them in replies
- [ ] Allow input formats more general than `1 2`, eg. `12`, `1, 2`
- [ ] Empty lines should be drawn under coloured lines
- [ ] Reduce output SVG size so it fits in CBTS preview box
- [ ] State strings should be compressed
- [ ] Needs messages for game over states
- [ ] AI's `optimal_play` key should be expanded to classify all options as `optimal`, `suboptimal`, or `losing`, for random selection
- [x] Allow AI to move first
- [ ] Messages/"taunts" during game to indicate whether the AI expects to win or lose with perfect play. Could even be dependent on previous state and determined by reply selection